### PR TITLE
Migrate Fabric8 Maven Plugin to Eclipse JKube's OpenShift Maven Plugin

### DIFF
--- a/Simulator-APIs/pom.xml
+++ b/Simulator-APIs/pom.xml
@@ -16,7 +16,7 @@
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <fabric8-maven-plugin.version>4.3.1</fabric8-maven-plugin.version>
+        <jkube.version>1.3.0</jkube.version>
 
         <!-- Red Hat 7.5 -->
         <!--<fuse.version>7.5.0.fuse-750029-redhat-00002</fuse.version>
@@ -184,12 +184,12 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <version>${fabric8-maven-plugin.version}</version>
+                        <groupId>org.eclipse.jkube</groupId>
+                        <artifactId>openshift-maven-plugin</artifactId>
+                        <version>${jkube.version}</version>
                         <executions>
                             <execution>
-                                <id>fabric8</id>
+                                <id>jkube</id>
                                 <goals>
                                     <goal>resource</goal>
                                     <goal>build</goal>

--- a/Simulator-FHIR/pom.xml
+++ b/Simulator-FHIR/pom.xml
@@ -16,7 +16,7 @@
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <fabric8-maven-plugin.version>4.3.1</fabric8-maven-plugin.version>
+        <jkube.version>1.3.0</jkube.version>
 
         <!-- Red Hat 7.5 -->
         <!--<fuse.version>7.5.0.fuse-750029-redhat-00002</fuse.version>
@@ -184,12 +184,12 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <version>${fabric8-maven-plugin.version}</version>
+                        <groupId>org.eclipse.jkube</groupId>
+                        <artifactId>openshift-maven-plugin</artifactId>
+                        <version>${jkube.version}</version>
                         <executions>
                             <execution>
-                                <id>fabric8</id>
+                                <id>jkube</id>
                                 <goals>
                                     <goal>resource</goal>
                                     <goal>build</goal>

--- a/Simulator-HL7/pom.xml
+++ b/Simulator-HL7/pom.xml
@@ -16,7 +16,7 @@
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <fabric8-maven-plugin.version>4.3.1</fabric8-maven-plugin.version>
+        <jkube.version>1.3.0</jkube.version>
 
         <!-- Red Hat 7.5 -->
         <!--<fuse.version>7.5.0.fuse-750029-redhat-00002</fuse.version>
@@ -184,12 +184,12 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <version>${fabric8-maven-plugin.version}</version>
+                        <groupId>org.eclipse.jkube</groupId>
+                        <artifactId>openshift-maven-plugin</artifactId>
+                        <version>${jkube.version}</version>
                         <executions>
                             <execution>
-                                <id>fabric8</id>
+                                <id>jkube</id>
                                 <goals>
                                     <goal>resource</goal>
                                     <goal>build</goal>

--- a/Simulator-KIC/pom.xml
+++ b/Simulator-KIC/pom.xml
@@ -16,7 +16,7 @@
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <fabric8-maven-plugin.version>4.3.1</fabric8-maven-plugin.version>
+        <jkube.version>1.3.0</jkube.version>
 
         <!-- Red Hat 7.5 -->
         <!--<fuse.version>7.5.0.fuse-750029-redhat-00002</fuse.version>
@@ -198,12 +198,12 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <version>${fabric8-maven-plugin.version}</version>
+                        <groupId>org.eclipse.jkube</groupId>
+                        <artifactId>openshift-maven-plugin</artifactId>
+                        <version>${jkube.version}</version>
                         <executions>
                             <execution>
-                                <id>fabric8</id>
+                                <id>jkube</id>
                                 <goals>
                                     <goal>resource</goal>
                                     <goal>build</goal>

--- a/Simulator-ThirdParty/pom.xml
+++ b/Simulator-ThirdParty/pom.xml
@@ -16,7 +16,7 @@
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <fabric8-maven-plugin.version>4.3.1</fabric8-maven-plugin.version>
+        <jkube.version>1.3.0</jkube.version>
 
         <!-- Red Hat 7.5 -->
         <!--<fuse.version>7.5.0.fuse-750029-redhat-00002</fuse.version>
@@ -180,12 +180,12 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
-                        <version>${fabric8-maven-plugin.version}</version>
+                        <groupId>org.eclipse.jkube</groupId>
+                        <artifactId>openshift-maven-plugin</artifactId>
+                        <version>${jkube.version}</version>
                         <executions>
                             <execution>
-                                <id>fabric8</id>
+                                <id>jkube</id>
                                 <goals>
                                     <goal>resource</goal>
                                     <goal>build</goal>


### PR DESCRIPTION
Migrate fabric8-maven-plugin to Eclipse JKube's openshift-maven-plugin.

[Eclipse JKube](https://github.com/eclipse/jkube) is the successor to Fabric8 Maven Plugin. We encourage using
[Eclipse JKube](https://github.com/eclipse/jkube) instead of FMP since support for FMP would be eventually
dropped in future.